### PR TITLE
Add !self.textField.markedTextRange check to trigger contactPickerTextViewDidChange

### DIFF
--- a/Classes/THContactPickerView.m
+++ b/Classes/THContactPickerView.m
@@ -460,7 +460,8 @@
 }
 
 - (void)textFieldDidChange:(THContactTextField *)textView{
-    if ([self.delegate respondsToSelector:@selector(contactPickerTextViewDidChange:)]){
+    if ([self.delegate respondsToSelector:@selector(contactPickerTextViewDidChange:)]
+     && !self.textField.markedTextRange) {
         [self.delegate contactPickerTextViewDidChange:textView.text];
     }
     


### PR DESCRIPTION
When we edit text with Japanese or Chinese keyboard, contactPickerTextViewDidChange is triggered before deciding which character to input. `!self.textField.markedTextRange` check prevent it. If you need more explanation, please let me know.