### PR TITLE
prevent unwanted placeholder from showing up

### DIFF
--- a/Classes/THContactPickerView.m
+++ b/Classes/THContactPickerView.m
@@ -409,7 +409,7 @@
 	}
 	
 	// Show placeholder if no there are no contacts
-	if (self.contacts.count == 0){
+    if ([self.textField.text isEqualToString:@""] && self.contacts.count == 0 ){
 		self.placeholderLabel.hidden = NO;
 	} else {
 		self.placeholderLabel.hidden = YES;


### PR DESCRIPTION
Bug This Fixes:

When I am typing in the text field, and a resize is triggered, the
placeholder text shows up right on top of the text i’ve typed.

Not sure why other people aren’t running into this. For me it happens
after i type the second or third character into the text field. Perhaps
characteristics of my layout are causing re-sizes more frequently than
otherwise.