### PR TITLE
expose the tint color of the text field (to control the cursor color)

### DIFF
--- a/Classes/THContactPickerView.h
+++ b/Classes/THContactPickerView.h
@@ -43,6 +43,7 @@
 - (void)setPromptLabelText:(NSString *)text;
 - (void)setPromptLabelAttributedText:(NSAttributedString *)attributedText;
 - (void)setPromptLabelTextColor:(UIColor *)color;
+- (void)setPromptTintColor:(UIColor *)color;
 - (void)setFont:(UIFont *)font;
 
 @end

--- a/Classes/THContactPickerView.m
+++ b/Classes/THContactPickerView.m
@@ -143,6 +143,10 @@
     self.promptLabel.textColor = color;
 }
 
+- (void)setPromptTintColor:(UIColor *)color{
+    self.textField.tintColor = color;
+}
+
 - (void)setBackgroundColor:(UIColor *)backgroundColor{
     self.scrollView.backgroundColor = backgroundColor;
     [super setBackgroundColor:backgroundColor];


### PR DESCRIPTION
With my color scheme, the default cursor color was nearly invisible.