### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ THContactPicker is an iOS view used for selecting contacts. It is built to mimic
 ![Screenshot](https://raw.githubusercontent.com/tristanhimmelman/THContactPicker/master/example.gif)
 
 ##Installation
-THContactPicker can be added to your project manually or using Cocoapods:
+THContactPicker can be added to your project manually or using CocoaPods:
 ```
 pod 'THContactPicker', '~> 2.0'
 ```


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
